### PR TITLE
Cooldown added if mission is failed.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -180,6 +180,8 @@ Citizen.CreateThread(function()
 				TriggerEvent('esx:showNotification', _U('get_back_car_10s'))
 				Wait(10000)
 				TriggerEvent('esx:showNotification', _U('mission_failed'))
+				TriggerServerEvent('esx_carthief:pay', 0) 
+				--Pay is called with 0 money reward so that cooldown is set on server side. 
 				AbortDelivery()
 			end
 		end


### PR DESCRIPTION
Cooldown is started if mission is failed in middle. This is important because if he is chased and caught by police , next robbery is not immediatly started.